### PR TITLE
ci: Remove Windows 2019 support from CI and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,6 @@ jobs:
           - os: windows-2022
             elixir-version: '1.18.4'
             otp-version: '28.0.1'
-          - os: windows-2019
-            elixir-version: '1.18.4'
-            otp-version: '28.0.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ be found at <https://hexdocs.pm/node_activator>.
 * Ubuntu 22.04 / Elixir 1.15 / OTP 25
 * Windows 2022 / Elixir 1.19 / OTP 28
 * Windows 2022 / Elixir 1.18 / OTP 28
-* Windows 2019 / Elixir 1.18 / OTP 28
 
 ## License
 


### PR DESCRIPTION
- Remove Windows 2019 test matrix entry from CI workflow
- Update README to remove Windows 2019 from supported platforms
- Windows 2022 remains supported for both Elixir 1.19 and 1.18